### PR TITLE
fix: restore GitHub readme summary mapping and enhance API response

### DIFF
--- a/api/src/main/kotlin/com/techinsights/api/github/GithubRepositoryResponse.kt
+++ b/api/src/main/kotlin/com/techinsights/api/github/GithubRepositoryResponse.kt
@@ -21,6 +21,7 @@ data class GithubRepositoryResponse(
     val dailyStarDelta: Long,
     val pushedAt: LocalDateTime,
     val fetchedAt: LocalDateTime,
+    val readmeSummary: String?,
     val communityStatus: CommunityStatus?,
     val communityMentionCount: Int?,
 ) {
@@ -41,6 +42,7 @@ data class GithubRepositoryResponse(
             dailyStarDelta = dto.dailyStarDelta,
             pushedAt = dto.pushedAt,
             fetchedAt = dto.fetchedAt,
+            readmeSummary = dto.readmeSummary,
             communityStatus = dto.communityStatus,
             communityMentionCount = dto.communityMentionCount,
         )

--- a/api/src/main/resources/logback-spring.xml
+++ b/api/src/main/resources/logback-spring.xml
@@ -68,8 +68,6 @@
 
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_FILE"/>
-            <appender-ref ref="ASYNC_ERROR_FILE"/>
         </root>
     </springProfile>
 

--- a/api/src/test/kotlin/com/techinsights/api/github/GithubRepositoryResponseTest.kt
+++ b/api/src/test/kotlin/com/techinsights/api/github/GithubRepositoryResponseTest.kt
@@ -9,6 +9,7 @@ import java.time.LocalDateTime
 class GithubRepositoryResponseTest : FunSpec({
 
     fun buildDto(
+        readmeSummary: String? = null,
         communityStatus: CommunityStatus? = null,
         communityMentionCount: Int? = null,
     ): GithubRepositoryDto = GithubRepositoryDto(
@@ -27,10 +28,18 @@ class GithubRepositoryResponseTest : FunSpec({
         fetchedAt = LocalDateTime.of(2024, 6, 2, 0, 0),
         weeklyStarDelta = 0L,
         dailyStarDelta = 0L,
-        readmeSummary = null,
+        readmeSummary = readmeSummary,
         communityStatus = communityStatus,
         communityMentionCount = communityMentionCount,
     )
+
+    test("fromDto - readmeSummary가 DTO 값으로 매핑된다") {
+        val dto = buildDto(readmeSummary = "AI Summary Text")
+
+        val response = GithubRepositoryResponse.fromDto(dto)
+
+        response.readmeSummary shouldBe "AI Summary Text"
+    }
 
     test("fromDto - communityStatus가 DTO 값으로 매핑된다") {
         val dto = buildDto(communityStatus = CommunityStatus.COMPLETED)

--- a/domain/src/main/kotlin/com/techinsights/domain/repository/github/GithubRepositoryRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/techinsights/domain/repository/github/GithubRepositoryRepositoryImpl.kt
@@ -30,15 +30,21 @@ class GithubRepositoryRepositoryImpl(
         cursor: GithubRepositoryCursor?,
     ): List<GithubRepositoryDto> {
         val repo = QGithubRepository.githubRepository
+        val readme = QGithubRepositoryReadme.githubRepositoryReadme
         val languageCondition = language?.let { repo.primaryLanguage.eq(it) }
         val cursorCondition = buildCursorCondition(repo, sortType, cursor)
 
-        return queryFactory.selectFrom(repo)
+        return queryFactory.select(repo, readme)
+            .from(repo)
+            .leftJoin(readme).on(readme.repoId.eq(repo.id))
             .where(languageCondition, cursorCondition)
             .orderBy(*buildOrderSpecifiers(repo, sortType))
             .limit(limit.toLong())
             .fetch()
-            .map { GithubRepositoryDto.fromEntity(it) }
+            .map { tuple ->
+                GithubRepositoryDto.fromEntity(tuple.get(repo)!!)
+                    .copy(readmeSummary = tuple.get(readme)?.readmeSummary)
+            }
     }
 
     override fun findRepositories(
@@ -47,16 +53,22 @@ class GithubRepositoryRepositoryImpl(
         language: String?,
     ): Page<GithubRepositoryDto> {
         val repo = QGithubRepository.githubRepository
+        val readme = QGithubRepositoryReadme.githubRepositoryReadme
 
         val languageCondition = language?.let { repo.primaryLanguage.eq(it) }
 
-        val results = queryFactory.selectFrom(repo)
+        val results = queryFactory.select(repo, readme)
+            .from(repo)
+            .leftJoin(readme).on(readme.repoId.eq(repo.id))
             .where(languageCondition)
             .orderBy(*buildOrderSpecifiers(repo, sortType))
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch()
-            .map { GithubRepositoryDto.fromEntity(it) }
+            .map { tuple ->
+                GithubRepositoryDto.fromEntity(tuple.get(repo)!!)
+                    .copy(readmeSummary = tuple.get(readme)?.readmeSummary)
+            }
 
         val total = queryFactory.select(repo.id.count())
             .from(repo)
@@ -69,14 +81,17 @@ class GithubRepositoryRepositoryImpl(
     override fun findById(id: Long): GithubRepositoryDto? {
         val repo = QGithubRepository.githubRepository
         val community = QGithubRepositoryCommunity.githubRepositoryCommunity
+        val readme = QGithubRepositoryReadme.githubRepositoryReadme
 
-        return queryFactory.select(repo, community)
+        return queryFactory.select(repo, community, readme)
             .from(repo)
             .leftJoin(community).on(community.repoId.eq(repo.id))
+            .leftJoin(readme).on(readme.repoId.eq(repo.id))
             .where(repo.id.eq(id))
             .fetchOne()
             ?.let { tuple ->
                 GithubRepositoryDto.fromEntity(tuple.get(repo)!!).copy(
+                    readmeSummary = tuple.get(readme)?.readmeSummary,
                     communityStatus = tuple.get(community)?.communityStatus,
                     communitySentiment = tuple.get(community)?.communitySentiment,
                     communityInsights = tuple.get(community)?.communityInsights,
@@ -110,13 +125,14 @@ class GithubRepositoryRepositoryImpl(
 
         val mainCondition = retryCondition?.let { neverAttempted.or(it) } ?: neverAttempted
 
-        return queryFactory.selectFrom(repo)
+        return queryFactory.select(repo, readme)
+            .from(repo)
             .leftJoin(readme).on(readme.repoId.eq(repo.id))
             .where(mainCondition, cursorCondition)
             .orderBy(repo.starCount.desc(), repo.id.desc())
             .limit(pageSize.toLong())
             .fetch()
-            .map { GithubRepositoryDto.fromEntity(it) }
+            .map { tuple -> GithubRepositoryDto.fromEntity(tuple.get(repo)!!) }
     }
 
     override fun findUnembedded(

--- a/domain/src/main/kotlin/com/techinsights/domain/repository/github/GithubRepositoryRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/techinsights/domain/repository/github/GithubRepositoryRepositoryImpl.kt
@@ -34,7 +34,7 @@ class GithubRepositoryRepositoryImpl(
         val languageCondition = language?.let { repo.primaryLanguage.eq(it) }
         val cursorCondition = buildCursorCondition(repo, sortType, cursor)
 
-        return queryFactory.select(repo, readme)
+        return queryFactory.select(repo, readme.readmeSummary)
             .from(repo)
             .leftJoin(readme).on(readme.repoId.eq(repo.id))
             .where(languageCondition, cursorCondition)
@@ -42,8 +42,8 @@ class GithubRepositoryRepositoryImpl(
             .limit(limit.toLong())
             .fetch()
             .map { tuple ->
-                GithubRepositoryDto.fromEntity(tuple.get(repo)!!)
-                    .copy(readmeSummary = tuple.get(readme)?.readmeSummary)
+                GithubRepositoryDto.fromEntity(tuple[repo]!!)
+                    .copy(readmeSummary = tuple[readme.readmeSummary])
             }
     }
 
@@ -57,7 +57,7 @@ class GithubRepositoryRepositoryImpl(
 
         val languageCondition = language?.let { repo.primaryLanguage.eq(it) }
 
-        val results = queryFactory.select(repo, readme)
+        val results = queryFactory.select(repo, readme.readmeSummary)
             .from(repo)
             .leftJoin(readme).on(readme.repoId.eq(repo.id))
             .where(languageCondition)
@@ -66,8 +66,8 @@ class GithubRepositoryRepositoryImpl(
             .limit(pageable.pageSize.toLong())
             .fetch()
             .map { tuple ->
-                GithubRepositoryDto.fromEntity(tuple.get(repo)!!)
-                    .copy(readmeSummary = tuple.get(readme)?.readmeSummary)
+                GithubRepositoryDto.fromEntity(tuple[repo]!!)
+                    .copy(readmeSummary = tuple[readme.readmeSummary])
             }
 
         val total = queryFactory.select(repo.id.count())
@@ -83,21 +83,21 @@ class GithubRepositoryRepositoryImpl(
         val community = QGithubRepositoryCommunity.githubRepositoryCommunity
         val readme = QGithubRepositoryReadme.githubRepositoryReadme
 
-        return queryFactory.select(repo, community, readme)
+        return queryFactory.select(repo, community, readme.readmeSummary)
             .from(repo)
             .leftJoin(community).on(community.repoId.eq(repo.id))
             .leftJoin(readme).on(readme.repoId.eq(repo.id))
             .where(repo.id.eq(id))
             .fetchOne()
             ?.let { tuple ->
-                GithubRepositoryDto.fromEntity(tuple.get(repo)!!).copy(
-                    readmeSummary = tuple.get(readme)?.readmeSummary,
-                    communityStatus = tuple.get(community)?.communityStatus,
-                    communitySentiment = tuple.get(community)?.communitySentiment,
-                    communityInsights = tuple.get(community)?.communityInsights,
-                    communityCollectedAt = tuple.get(community)?.communityCollectedAt,
-                    communityMentionCount = tuple.get(community)?.communityMentionCount,
-                    communityHighlights = tuple.get(community)?.communityHighlights,
+                GithubRepositoryDto.fromEntity(tuple[repo]!!).copy(
+                    readmeSummary = tuple[readme.readmeSummary],
+                    communityStatus = tuple[community]?.communityStatus,
+                    communitySentiment = tuple[community]?.communitySentiment,
+                    communityInsights = tuple[community]?.communityInsights,
+                    communityCollectedAt = tuple[community]?.communityCollectedAt,
+                    communityMentionCount = tuple[community]?.communityMentionCount,
+                    communityHighlights = tuple[community]?.communityHighlights,
                 )
             }
     }
@@ -125,14 +125,13 @@ class GithubRepositoryRepositoryImpl(
 
         val mainCondition = retryCondition?.let { neverAttempted.or(it) } ?: neverAttempted
 
-        return queryFactory.select(repo, readme)
-            .from(repo)
+        return queryFactory.selectFrom(repo)
             .leftJoin(readme).on(readme.repoId.eq(repo.id))
             .where(mainCondition, cursorCondition)
             .orderBy(repo.starCount.desc(), repo.id.desc())
             .limit(pageSize.toLong())
             .fetch()
-            .map { tuple -> GithubRepositoryDto.fromEntity(tuple.get(repo)!!) }
+            .map { GithubRepositoryDto.fromEntity(it) }
     }
 
     override fun findUnembedded(
@@ -148,7 +147,7 @@ class GithubRepositoryRepositoryImpl(
                 .or(repo.starCount.eq(afterStarCount).and(repo.id.lt(afterId)))
         } else null
 
-        return queryFactory.select(repo, readme)
+        return queryFactory.select(repo, readme.readmeSummary)
             .from(repo)
             .join(readme).on(readme.repoId.eq(repo.id))
             .where(
@@ -161,8 +160,8 @@ class GithubRepositoryRepositoryImpl(
             .limit(pageSize.toLong())
             .fetch()
             .map { tuple ->
-                GithubRepositoryDto.fromEntity(tuple.get(repo)!!)
-                    .copy(readmeSummary = tuple.get(readme)?.readmeSummary)
+                GithubRepositoryDto.fromEntity(tuple[repo]!!)
+                    .copy(readmeSummary = tuple[readme.readmeSummary])
             }
     }
 
@@ -201,13 +200,13 @@ class GithubRepositoryRepositoryImpl(
             .limit(pageSize.toLong())
             .fetch()
             .map { tuple ->
-                GithubRepositoryDto.fromEntity(tuple.get(repo)!!).copy(
-                    communityStatus = tuple.get(community)?.communityStatus,
-                    communityCollectedAt = tuple.get(community)?.communityCollectedAt,
-                    communityMentionCount = tuple.get(community)?.communityMentionCount,
-                    communityRawMentionCount = tuple.get(community)?.communityRawMentionCount,
-                    communityUpdateCount = tuple.get(community)?.communityUpdateCount ?: 0,
-                    communityHighlights = tuple.get(community)?.communityHighlights,
+                GithubRepositoryDto.fromEntity(tuple[repo]!!).copy(
+                    communityStatus = tuple[community]?.communityStatus,
+                    communityCollectedAt = tuple[community]?.communityCollectedAt,
+                    communityMentionCount = tuple[community]?.communityMentionCount,
+                    communityRawMentionCount = tuple[community]?.communityRawMentionCount,
+                    communityUpdateCount = tuple[community]?.communityUpdateCount ?: 0,
+                    communityHighlights = tuple[community]?.communityHighlights,
                 )
             }
     }
@@ -232,13 +231,13 @@ class GithubRepositoryRepositoryImpl(
             .limit(pageSize.toLong())
             .fetch()
             .map { tuple ->
-                GithubRepositoryDto.fromEntity(tuple.get(repo)!!).copy(
-                    communityStatus = tuple.get(community)?.communityStatus,
-                    communityCollectedAt = tuple.get(community)?.communityCollectedAt,
-                    communityMentionCount = tuple.get(community)?.communityMentionCount,
-                    communityRawMentionCount = tuple.get(community)?.communityRawMentionCount,
-                    communityUpdateCount = tuple.get(community)?.communityUpdateCount ?: 0,
-                    communityHighlights = tuple.get(community)?.communityHighlights,
+                GithubRepositoryDto.fromEntity(tuple[repo]!!).copy(
+                    communityStatus = tuple[community]?.communityStatus,
+                    communityCollectedAt = tuple[community]?.communityCollectedAt,
+                    communityMentionCount = tuple[community]?.communityMentionCount,
+                    communityRawMentionCount = tuple[community]?.communityRawMentionCount,
+                    communityUpdateCount = tuple[community]?.communityUpdateCount ?: 0,
+                    communityHighlights = tuple[community]?.communityHighlights,
                 )
             }
     }

--- a/domain/src/test/kotlin/com/techinsights/domain/repository/github/GithubRepositoryRepositoryImplCommunityInsightTest.kt
+++ b/domain/src/test/kotlin/com/techinsights/domain/repository/github/GithubRepositoryRepositoryImplCommunityInsightTest.kt
@@ -51,8 +51,8 @@ class GithubRepositoryRepositoryImplCommunityInsightTest : FunSpec({
         community: GithubRepositoryCommunity?,
     ): Tuple {
         val tuple = mockk<Tuple>()
-        every { tuple.get(QGithubRepository.githubRepository) } returns entity
-        every { tuple.get(QGithubRepositoryCommunity.githubRepositoryCommunity) } returns community
+        every { tuple[QGithubRepository.githubRepository] } returns entity
+        every { tuple[QGithubRepositoryCommunity.githubRepositoryCommunity] } returns community
         return tuple
     }
 

--- a/domain/src/test/kotlin/com/techinsights/domain/repository/github/GithubRepositoryRepositoryImplTest.kt
+++ b/domain/src/test/kotlin/com/techinsights/domain/repository/github/GithubRepositoryRepositoryImplTest.kt
@@ -6,7 +6,6 @@ import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.techinsights.domain.entity.github.GithubRepository
 import com.techinsights.domain.entity.github.QGithubRepositoryCommunity
-import com.techinsights.domain.entity.github.GithubRepositoryReadme
 import com.techinsights.domain.entity.github.QGithubRepository
 import com.techinsights.domain.entity.github.QGithubRepositoryReadme
 import com.techinsights.domain.enums.ErrorType
@@ -43,9 +42,8 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val countQuery = mockk<JPAQuery<Long>>()
             val tuple1 = mockk<Tuple>()
             val tuple2 = mockk<Tuple>()
-            val readme1 = GithubRepositoryReadme(repoId = 1L, readmeSummary = "summary 1")
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary) } returns query
             every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
@@ -55,10 +53,10 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             every { query.limit(20L) } returns query
             every { query.fetch() } returns listOf(tuple1, tuple2)
 
-            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
-            every { tuple1.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns readme1
-            every { tuple2.get(QGithubRepository.githubRepository) } returns entity2
-            every { tuple2.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
+            every { tuple1[QGithubRepository.githubRepository] } returns entity1
+            every { tuple1[QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary] } returns "summary 1"
+            every { tuple2[QGithubRepository.githubRepository] } returns entity2
+            every { tuple2[QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary] } returns null
 
             every { queryFactory.select(QGithubRepository.githubRepository.id.count()) } returns countQuery
             every { countQuery.from(QGithubRepository.githubRepository) } returns countQuery
@@ -79,7 +77,7 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val countQuery = mockk<JPAQuery<Long>>()
             val tuple1 = mockk<Tuple>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary) } returns query
             every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
@@ -89,8 +87,8 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             every { query.limit(20L) } returns query
             every { query.fetch() } returns listOf(tuple1)
 
-            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
-            every { tuple1.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
+            every { tuple1[QGithubRepository.githubRepository] } returns entity1
+            every { tuple1[QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary] } returns null
 
             every { queryFactory.select(QGithubRepository.githubRepository.id.count()) } returns countQuery
             every { countQuery.from(QGithubRepository.githubRepository) } returns countQuery
@@ -110,7 +108,7 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val countQuery = mockk<JPAQuery<Long>>()
             val tuple1 = mockk<Tuple>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary) } returns query
             every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
@@ -120,8 +118,8 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             every { query.limit(10L) } returns query
             every { query.fetch() } returns listOf(tuple1)
 
-            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
-            every { tuple1.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
+            every { tuple1[QGithubRepository.githubRepository] } returns entity1
+            every { tuple1[QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary] } returns null
 
             every { queryFactory.select(QGithubRepository.githubRepository.id.count()) } returns countQuery
             every { countQuery.from(QGithubRepository.githubRepository) } returns countQuery
@@ -140,7 +138,7 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val countQuery = mockk<JPAQuery<Long>>()
             val tuple1 = mockk<Tuple>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary) } returns query
             every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
@@ -150,8 +148,8 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             every { query.limit(10L) } returns query
             every { query.fetch() } returns listOf(tuple1)
 
-            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
-            every { tuple1.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
+            every { tuple1[QGithubRepository.githubRepository] } returns entity1
+            every { tuple1[QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary] } returns null
 
             every { queryFactory.select(QGithubRepository.githubRepository.id.count()) } returns countQuery
             every { countQuery.from(QGithubRepository.githubRepository) } returns countQuery
@@ -174,7 +172,7 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val highDailyEntity = buildEntity(id = 1L, fullName = "owner/repo1", dailyDelta = 100L)
             val lowDailyEntity = buildEntity(id = 2L, fullName = "owner/repo2", dailyDelta = 10L)
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary) } returns query
             every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
@@ -184,10 +182,10 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             every { query.limit(10L) } returns query
             every { query.fetch() } returns listOf(tuple1, tuple2)
 
-            every { tuple1.get(QGithubRepository.githubRepository) } returns highDailyEntity
-            every { tuple1.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
-            every { tuple2.get(QGithubRepository.githubRepository) } returns lowDailyEntity
-            every { tuple2.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
+            every { tuple1[QGithubRepository.githubRepository] } returns highDailyEntity
+            every { tuple1[QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary] } returns null
+            every { tuple2[QGithubRepository.githubRepository] } returns lowDailyEntity
+            every { tuple2[QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary] } returns null
 
             every { queryFactory.select(QGithubRepository.githubRepository.id.count()) } returns countQuery
             every { countQuery.from(QGithubRepository.githubRepository) } returns countQuery
@@ -207,7 +205,7 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val query = mockk<JPAQuery<Tuple>>()
             val countQuery = mockk<JPAQuery<Long>>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary) } returns query
             every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
@@ -233,7 +231,7 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val query = mockk<JPAQuery<Tuple>>()
             val countQuery = mockk<JPAQuery<Long>>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme.readmeSummary) } returns query
             every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
@@ -264,7 +262,7 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val query = mockk<JPAQuery<Tuple>>()
             val tuple = mockk<Tuple>()
 
-            every { queryFactory.select(repo, community, readme) } returns query
+            every { queryFactory.select(repo, community, readme.readmeSummary) } returns query
             every { query.from(repo) } returns query
             every { query.leftJoin(community) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
@@ -272,9 +270,9 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>()) } returns query
             every { query.fetchOne() } returns tuple
-            every { tuple.get(repo) } returns entity1
-            every { tuple.get(community) } returns null
-            every { tuple.get(readme) } returns GithubRepositoryReadme(repoId = 1L, readmeSummary = "detailed summary")
+            every { tuple[repo] } returns entity1
+            every { tuple[community] } returns null
+            every { tuple[readme.readmeSummary] } returns "detailed summary"
 
             val result = repository.findById(1L)
 
@@ -289,7 +287,7 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val readme = QGithubRepositoryReadme.githubRepositoryReadme
             val query = mockk<JPAQuery<Tuple>>()
 
-            every { queryFactory.select(repo, community, readme) } returns query
+            every { queryFactory.select(repo, community, readme.readmeSummary) } returns query
             every { query.from(repo) } returns query
             every { query.leftJoin(community) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
@@ -308,21 +306,15 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
     context("findUnsummarized") {
 
         test("cursor 없이 호출하면 readmeSummarizedAt=null인 레포를 반환한다") {
-            val query = mockk<JPAQuery<Tuple>>()
-            val tuple1 = mockk<Tuple>()
-            val tuple2 = mockk<Tuple>()
+            val query = mockk<JPAQuery<GithubRepository>>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
-            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(tuple1, tuple2)
-
-            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
-            every { tuple2.get(QGithubRepository.githubRepository) } returns entity2
+            every { query.fetch() } returns listOf(entity1, entity2)
 
             val result = repository.findUnsummarized(pageSize = 10, afterStarCount = null, afterId = null)
 
@@ -330,19 +322,15 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
         }
 
         test("cursor를 지정하면 해당 cursor 이후 결과를 반환한다") {
-            val query = mockk<JPAQuery<Tuple>>()
-            val tuple2 = mockk<Tuple>()
+            val query = mockk<JPAQuery<GithubRepository>>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
-            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), any<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(tuple2)
-
-            every { tuple2.get(QGithubRepository.githubRepository) } returns entity2
+            every { query.fetch() } returns listOf(entity2)
 
             val result = repository.findUnsummarized(pageSize = 10, afterStarCount = 2000L, afterId = 1L)
 
@@ -352,10 +340,9 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
         }
 
         test("결과가 없으면 빈 리스트를 반환한다") {
-            val query = mockk<JPAQuery<Tuple>>()
+            val query = mockk<JPAQuery<GithubRepository>>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
-            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
@@ -369,10 +356,9 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
         }
 
         test("pageSize가 limit()에 정확히 전달된다") {
-            val query = mockk<JPAQuery<Tuple>>()
+            val query = mockk<JPAQuery<GithubRepository>>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
-            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
@@ -387,19 +373,15 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
         test("topics 쉼표 구분 문자열이 List로 올바르게 변환된다") {
             val entityWithTopics = buildEntity(id = 3L, fullName = "owner/repo3", topics = "kotlin,spring,batch")
-            val query = mockk<JPAQuery<Tuple>>()
-            val tuple3 = mockk<Tuple>()
+            val query = mockk<JPAQuery<GithubRepository>>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
-            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(tuple3)
-
-            every { tuple3.get(QGithubRepository.githubRepository) } returns entityWithTopics
+            every { query.fetch() } returns listOf(entityWithTopics)
 
             val result = repository.findUnsummarized(pageSize = 10, afterStarCount = null, afterId = null)
 
@@ -407,19 +389,15 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
         }
 
         test("retryAfter와 retryableErrorTypes 설정 시 결과를 반환한다") {
-            val query = mockk<JPAQuery<Tuple>>()
-            val tuple1 = mockk<Tuple>()
+            val query = mockk<JPAQuery<GithubRepository>>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
-            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(tuple1)
-
-            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
+            every { query.fetch() } returns listOf(entity1)
 
             val result = repository.findUnsummarized(
                 pageSize = 10,
@@ -433,19 +411,15 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
         }
 
         test("retryableErrorTypes가 빈 Set이면 retryAfter가 있어도 neverAttempted 조건만 사용한다") {
-            val query = mockk<JPAQuery<Tuple>>()
-            val tuple1 = mockk<Tuple>()
+            val query = mockk<JPAQuery<GithubRepository>>()
 
-            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
-            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(tuple1)
-
-            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
+            every { query.fetch() } returns listOf(entity1)
 
             val result = repository.findUnsummarized(
                 pageSize = 10,
@@ -463,25 +437,23 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
         test("cursor 없이 호출하면 요약은 됐지만 아직 임베딩 안 된 레포를 반환한다") {
             val tupleQuery = mockk<JPAQuery<Tuple>>()
-            val readme1 = GithubRepositoryReadme(repoId = 1L, readmeSummary = "summary1")
-            val readme2 = GithubRepositoryReadme(repoId = 2L, readmeSummary = "summary2")
             val tuple1 = mockk<Tuple>()
             val tuple2 = mockk<Tuple>()
 
             val repo = QGithubRepository.githubRepository
             val readme = QGithubRepositoryReadme.githubRepositoryReadme
 
-            every { queryFactory.select(repo, readme) } returns tupleQuery
+            every { queryFactory.select(repo, readme.readmeSummary) } returns tupleQuery
             every { tupleQuery.from(repo) } returns tupleQuery
             every { tupleQuery.join(readme) } returns tupleQuery
             every { tupleQuery.on(any<BooleanExpression>()) } returns tupleQuery
             every { tupleQuery.where(any(), any(), any(), isNull()) } returns tupleQuery
             every { tupleQuery.orderBy(any(), any()) } returns tupleQuery
             every { tupleQuery.limit(10L) } returns tupleQuery
-            every { tuple1.get(repo) } returns entity1
-            every { tuple1.get(readme) } returns readme1
-            every { tuple2.get(repo) } returns entity2
-            every { tuple2.get(readme) } returns readme2
+            every { tuple1[repo] } returns entity1
+            every { tuple1[readme.readmeSummary] } returns "summary1"
+            every { tuple2[repo] } returns entity2
+            every { tuple2[readme.readmeSummary] } returns "summary2"
             every { tupleQuery.fetch() } returns listOf(tuple1, tuple2)
 
             val result = repository.findUnembedded(pageSize = 10, afterStarCount = null, afterId = null)
@@ -491,21 +463,20 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
         test("cursor를 지정하면 해당 cursor 이후 결과를 반환한다") {
             val tupleQuery = mockk<JPAQuery<Tuple>>()
-            val readme2 = GithubRepositoryReadme(repoId = 2L, readmeSummary = "summary2")
             val tuple2 = mockk<Tuple>()
 
             val repo = QGithubRepository.githubRepository
             val readme = QGithubRepositoryReadme.githubRepositoryReadme
 
-            every { queryFactory.select(repo, readme) } returns tupleQuery
+            every { queryFactory.select(repo, readme.readmeSummary) } returns tupleQuery
             every { tupleQuery.from(repo) } returns tupleQuery
             every { tupleQuery.join(readme) } returns tupleQuery
             every { tupleQuery.on(any<BooleanExpression>()) } returns tupleQuery
             every { tupleQuery.where(any(), any(), any(), any<BooleanExpression>()) } returns tupleQuery
             every { tupleQuery.orderBy(any(), any()) } returns tupleQuery
             every { tupleQuery.limit(10L) } returns tupleQuery
-            every { tuple2.get(repo) } returns entity2
-            every { tuple2.get(readme) } returns readme2
+            every { tuple2[repo] } returns entity2
+            every { tuple2[readme.readmeSummary] } returns "summary2"
             every { tupleQuery.fetch() } returns listOf(tuple2)
 
             val result = repository.findUnembedded(pageSize = 10, afterStarCount = 2000L, afterId = 1L)
@@ -519,7 +490,7 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val repo = QGithubRepository.githubRepository
             val readme = QGithubRepositoryReadme.githubRepositoryReadme
 
-            every { queryFactory.select(repo, readme) } returns tupleQuery
+            every { queryFactory.select(repo, readme.readmeSummary) } returns tupleQuery
             every { tupleQuery.from(repo) } returns tupleQuery
             every { tupleQuery.join(readme) } returns tupleQuery
             every { tupleQuery.on(any<BooleanExpression>()) } returns tupleQuery
@@ -538,7 +509,7 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val repo = QGithubRepository.githubRepository
             val readme = QGithubRepositoryReadme.githubRepositoryReadme
 
-            every { queryFactory.select(repo, readme) } returns tupleQuery
+            every { queryFactory.select(repo, readme.readmeSummary) } returns tupleQuery
             every { tupleQuery.from(repo) } returns tupleQuery
             every { tupleQuery.join(readme) } returns tupleQuery
             every { tupleQuery.on(any<BooleanExpression>()) } returns tupleQuery
@@ -554,13 +525,13 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
     }
 
     context("findRepositoriesByCursor") {
-        test("cursor를 사용하여 레포지토리를 조회한다") {
+        test("기본 조건으로 레포지토리를 조회한다") {
             val repo = QGithubRepository.githubRepository
             val readme = QGithubRepositoryReadme.githubRepositoryReadme
             val query = mockk<JPAQuery<Tuple>>()
             val tuple1 = mockk<Tuple>()
 
-            every { queryFactory.select(repo, readme) } returns query
+            every { queryFactory.select(repo, readme.readmeSummary) } returns query
             every { query.from(repo) } returns query
             every { query.leftJoin(readme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
@@ -568,8 +539,8 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
             every { query.fetch() } returns listOf(tuple1)
-            every { tuple1.get(repo) } returns entity1
-            every { tuple1.get(readme) } returns null
+            every { tuple1[repo] } returns entity1
+            every { tuple1[readme.readmeSummary] } returns null
 
             val result = repository.findRepositoriesByCursor(10, GithubSortType.STARS, null, null)
 
@@ -593,8 +564,8 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
             every { query.fetch() } returns listOf(tuple1)
-            every { tuple1.get(repo) } returns entity1
-            every { tuple1.get(community) } returns null
+            every { tuple1[repo] } returns entity1
+            every { tuple1[community] } returns null
 
             val result = repository.findForCommunityCollect(
                 10, null, null,
@@ -620,8 +591,8 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             every { query.orderBy(any()) } returns query
             every { query.limit(10L) } returns query
             every { query.fetch() } returns listOf(tuple1)
-            every { tuple1.get(repo) } returns entity1
-            every { tuple1.get(community) } returns null
+            every { tuple1[repo] } returns entity1
+            every { tuple1[community] } returns null
 
             val result = repository.findForCommunityAnalyze(10, null)
 

--- a/domain/src/test/kotlin/com/techinsights/domain/repository/github/GithubRepositoryRepositoryImplTest.kt
+++ b/domain/src/test/kotlin/com/techinsights/domain/repository/github/GithubRepositoryRepositoryImplTest.kt
@@ -37,17 +37,28 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
     context("findRepositories") {
 
-        test("STARS 정렬, language 필터 없이 조회하면 전체 결과를 반환한다") {
+        test("STARS 정렬, language 필터 없이 조회하면 readme 정보를 포함하여 반환한다") {
             val pageable = PageRequest.of(0, 20)
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
             val countQuery = mockk<JPAQuery<Long>>()
+            val tuple1 = mockk<Tuple>()
+            val tuple2 = mockk<Tuple>()
+            val readme1 = GithubRepositoryReadme(repoId = 1L, readmeSummary = "summary 1")
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.offset(0L) } returns query
             every { query.limit(20L) } returns query
-            every { query.fetch() } returns listOf(entity1, entity2)
+            every { query.fetch() } returns listOf(tuple1, tuple2)
+
+            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
+            every { tuple1.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns readme1
+            every { tuple2.get(QGithubRepository.githubRepository) } returns entity2
+            every { tuple2.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
 
             every { queryFactory.select(QGithubRepository.githubRepository.id.count()) } returns countQuery
             every { countQuery.from(QGithubRepository.githubRepository) } returns countQuery
@@ -57,20 +68,29 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val result = repository.findRepositories(pageable, GithubSortType.STARS, null)
 
             result.content shouldHaveSize 2
+            result.content[0].readmeSummary shouldBe "summary 1"
+            result.content[1].readmeSummary.shouldBeNull()
             result.totalElements shouldBe 2L
         }
 
         test("language 필터를 적용하면 해당 언어 레포만 반환한다") {
             val pageable = PageRequest.of(0, 20)
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
             val countQuery = mockk<JPAQuery<Long>>()
+            val tuple1 = mockk<Tuple>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.offset(0L) } returns query
             every { query.limit(20L) } returns query
-            every { query.fetch() } returns listOf(entity1)
+            every { query.fetch() } returns listOf(tuple1)
+
+            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
+            every { tuple1.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
 
             every { queryFactory.select(QGithubRepository.githubRepository.id.count()) } returns countQuery
             every { countQuery.from(QGithubRepository.githubRepository) } returns countQuery
@@ -86,15 +106,22 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
         test("LATEST 정렬로 조회하면 orderBy가 호출된다") {
             val pageable = PageRequest.of(0, 10)
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
             val countQuery = mockk<JPAQuery<Long>>()
+            val tuple1 = mockk<Tuple>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.offset(0L) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(entity1)
+            every { query.fetch() } returns listOf(tuple1)
+
+            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
+            every { tuple1.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
 
             every { queryFactory.select(QGithubRepository.githubRepository.id.count()) } returns countQuery
             every { countQuery.from(QGithubRepository.githubRepository) } returns countQuery
@@ -109,15 +136,22 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
         test("TRENDING 정렬로 조회하면 orderBy가 호출된다") {
             val pageable = PageRequest.of(0, 10)
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
             val countQuery = mockk<JPAQuery<Long>>()
+            val tuple1 = mockk<Tuple>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any(), any()) } returns query
             every { query.offset(0L) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(entity1)
+            every { query.fetch() } returns listOf(tuple1)
+
+            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
+            every { tuple1.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
 
             every { queryFactory.select(QGithubRepository.githubRepository.id.count()) } returns countQuery
             every { countQuery.from(QGithubRepository.githubRepository) } returns countQuery
@@ -132,18 +166,28 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
         test("DAILY_TRENDING 정렬로 조회하면 daily_star_delta DESC 순으로 반환된다") {
             val pageable = PageRequest.of(0, 10)
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
             val countQuery = mockk<JPAQuery<Long>>()
+            val tuple1 = mockk<Tuple>()
+            val tuple2 = mockk<Tuple>()
 
             val highDailyEntity = buildEntity(id = 1L, fullName = "owner/repo1", dailyDelta = 100L)
             val lowDailyEntity = buildEntity(id = 2L, fullName = "owner/repo2", dailyDelta = 10L)
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any(), any()) } returns query
             every { query.offset(0L) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(highDailyEntity, lowDailyEntity)
+            every { query.fetch() } returns listOf(tuple1, tuple2)
+
+            every { tuple1.get(QGithubRepository.githubRepository) } returns highDailyEntity
+            every { tuple1.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
+            every { tuple2.get(QGithubRepository.githubRepository) } returns lowDailyEntity
+            every { tuple2.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns null
 
             every { queryFactory.select(QGithubRepository.githubRepository.id.count()) } returns countQuery
             every { countQuery.from(QGithubRepository.githubRepository) } returns countQuery
@@ -160,10 +204,13 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
         test("결과가 없으면 totalElements=0인 빈 Page를 반환한다") {
             val pageable = PageRequest.of(0, 20)
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
             val countQuery = mockk<JPAQuery<Long>>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.offset(0L) } returns query
@@ -183,10 +230,13 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
         test("pageable의 offset과 limit이 쿼리에 올바르게 전달된다") {
             val pageable = PageRequest.of(2, 5)   // offset = 10, limit = 5
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
             val countQuery = mockk<JPAQuery<Long>>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
+            every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.offset(10L) } returns query
@@ -207,37 +257,43 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
     context("findById") {
 
-        test("존재하는 id로 조회하면 DTO를 반환한다") {
+        test("존재하는 id로 조회하면 readme 정보를 포함하여 DTO를 반환한다") {
             val repo = QGithubRepository.githubRepository
             val community = QGithubRepositoryCommunity.githubRepositoryCommunity
+            val readme = QGithubRepositoryReadme.githubRepositoryReadme
             val query = mockk<JPAQuery<Tuple>>()
             val tuple = mockk<Tuple>()
 
-            every { queryFactory.select(repo, community) } returns query
+            every { queryFactory.select(repo, community, readme) } returns query
             every { query.from(repo) } returns query
             every { query.leftJoin(community) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
+            every { query.leftJoin(readme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>()) } returns query
             every { query.fetchOne() } returns tuple
             every { tuple.get(repo) } returns entity1
             every { tuple.get(community) } returns null
+            every { tuple.get(readme) } returns GithubRepositoryReadme(repoId = 1L, readmeSummary = "detailed summary")
 
             val result = repository.findById(1L)
 
             result.shouldNotBeNull()
+            result.readmeSummary shouldBe "detailed summary"
             result.fullName shouldBe "owner/repo1"
-            result.starCount shouldBe 2000L
-            result.primaryLanguage shouldBe "Kotlin"
         }
 
         test("존재하지 않는 id로 조회하면 null을 반환한다") {
             val repo = QGithubRepository.githubRepository
             val community = QGithubRepositoryCommunity.githubRepositoryCommunity
+            val readme = QGithubRepositoryReadme.githubRepositoryReadme
             val query = mockk<JPAQuery<Tuple>>()
 
-            every { queryFactory.select(repo, community) } returns query
+            every { queryFactory.select(repo, community, readme) } returns query
             every { query.from(repo) } returns query
             every { query.leftJoin(community) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
+            every { query.leftJoin(readme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>()) } returns query
             every { query.fetchOne() } returns null
@@ -252,15 +308,21 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
     context("findUnsummarized") {
 
         test("cursor 없이 호출하면 readmeSummarizedAt=null인 레포를 반환한다") {
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
+            val tuple1 = mockk<Tuple>()
+            val tuple2 = mockk<Tuple>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(entity1, entity2)
+            every { query.fetch() } returns listOf(tuple1, tuple2)
+
+            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
+            every { tuple2.get(QGithubRepository.githubRepository) } returns entity2
 
             val result = repository.findUnsummarized(pageSize = 10, afterStarCount = null, afterId = null)
 
@@ -268,15 +330,19 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
         }
 
         test("cursor를 지정하면 해당 cursor 이후 결과를 반환한다") {
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
+            val tuple2 = mockk<Tuple>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), any<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(entity2)
+            every { query.fetch() } returns listOf(tuple2)
+
+            every { tuple2.get(QGithubRepository.githubRepository) } returns entity2
 
             val result = repository.findUnsummarized(pageSize = 10, afterStarCount = 2000L, afterId = 1L)
 
@@ -286,9 +352,10 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
         }
 
         test("결과가 없으면 빈 리스트를 반환한다") {
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
@@ -302,9 +369,10 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
         }
 
         test("pageSize가 limit()에 정확히 전달된다") {
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
@@ -319,15 +387,19 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
         test("topics 쉼표 구분 문자열이 List로 올바르게 변환된다") {
             val entityWithTopics = buildEntity(id = 3L, fullName = "owner/repo3", topics = "kotlin,spring,batch")
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
+            val tuple3 = mockk<Tuple>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(entityWithTopics)
+            every { query.fetch() } returns listOf(tuple3)
+
+            every { tuple3.get(QGithubRepository.githubRepository) } returns entityWithTopics
 
             val result = repository.findUnsummarized(pageSize = 10, afterStarCount = null, afterId = null)
 
@@ -335,15 +407,19 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
         }
 
         test("retryAfter와 retryableErrorTypes 설정 시 결과를 반환한다") {
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
+            val tuple1 = mockk<Tuple>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(entity1)
+            every { query.fetch() } returns listOf(tuple1)
+
+            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
 
             val result = repository.findUnsummarized(
                 pageSize = 10,
@@ -357,15 +433,19 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
         }
 
         test("retryableErrorTypes가 빈 Set이면 retryAfter가 있어도 neverAttempted 조건만 사용한다") {
-            val query = mockk<JPAQuery<GithubRepository>>()
+            val query = mockk<JPAQuery<Tuple>>()
+            val tuple1 = mockk<Tuple>()
 
-            every { queryFactory.selectFrom(QGithubRepository.githubRepository) } returns query
+            every { queryFactory.select(QGithubRepository.githubRepository, QGithubRepositoryReadme.githubRepositoryReadme) } returns query
+            every { query.from(QGithubRepository.githubRepository) } returns query
             every { query.leftJoin(QGithubRepositoryReadme.githubRepositoryReadme) } returns query
             every { query.on(any<BooleanExpression>()) } returns query
             every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
             every { query.orderBy(any(), any()) } returns query
             every { query.limit(10L) } returns query
-            every { query.fetch() } returns listOf(entity1)
+            every { query.fetch() } returns listOf(tuple1)
+
+            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
 
             val result = repository.findUnsummarized(
                 pageSize = 10,
@@ -388,17 +468,20 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val tuple1 = mockk<Tuple>()
             val tuple2 = mockk<Tuple>()
 
-            every { queryFactory.select(any(), any()) } returns tupleQuery
-            every { tupleQuery.from(QGithubRepository.githubRepository) } returns tupleQuery
-            every { tupleQuery.join(QGithubRepositoryReadme.githubRepositoryReadme) } returns tupleQuery
+            val repo = QGithubRepository.githubRepository
+            val readme = QGithubRepositoryReadme.githubRepositoryReadme
+
+            every { queryFactory.select(repo, readme) } returns tupleQuery
+            every { tupleQuery.from(repo) } returns tupleQuery
+            every { tupleQuery.join(readme) } returns tupleQuery
             every { tupleQuery.on(any<BooleanExpression>()) } returns tupleQuery
             every { tupleQuery.where(any(), any(), any(), isNull()) } returns tupleQuery
             every { tupleQuery.orderBy(any(), any()) } returns tupleQuery
             every { tupleQuery.limit(10L) } returns tupleQuery
-            every { tuple1.get(QGithubRepository.githubRepository) } returns entity1
-            every { tuple1.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns readme1
-            every { tuple2.get(QGithubRepository.githubRepository) } returns entity2
-            every { tuple2.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns readme2
+            every { tuple1.get(repo) } returns entity1
+            every { tuple1.get(readme) } returns readme1
+            every { tuple2.get(repo) } returns entity2
+            every { tuple2.get(readme) } returns readme2
             every { tupleQuery.fetch() } returns listOf(tuple1, tuple2)
 
             val result = repository.findUnembedded(pageSize = 10, afterStarCount = null, afterId = null)
@@ -411,15 +494,18 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             val readme2 = GithubRepositoryReadme(repoId = 2L, readmeSummary = "summary2")
             val tuple2 = mockk<Tuple>()
 
-            every { queryFactory.select(any(), any()) } returns tupleQuery
-            every { tupleQuery.from(QGithubRepository.githubRepository) } returns tupleQuery
-            every { tupleQuery.join(QGithubRepositoryReadme.githubRepositoryReadme) } returns tupleQuery
+            val repo = QGithubRepository.githubRepository
+            val readme = QGithubRepositoryReadme.githubRepositoryReadme
+
+            every { queryFactory.select(repo, readme) } returns tupleQuery
+            every { tupleQuery.from(repo) } returns tupleQuery
+            every { tupleQuery.join(readme) } returns tupleQuery
             every { tupleQuery.on(any<BooleanExpression>()) } returns tupleQuery
             every { tupleQuery.where(any(), any(), any(), any<BooleanExpression>()) } returns tupleQuery
             every { tupleQuery.orderBy(any(), any()) } returns tupleQuery
             every { tupleQuery.limit(10L) } returns tupleQuery
-            every { tuple2.get(QGithubRepository.githubRepository) } returns entity2
-            every { tuple2.get(QGithubRepositoryReadme.githubRepositoryReadme) } returns readme2
+            every { tuple2.get(repo) } returns entity2
+            every { tuple2.get(readme) } returns readme2
             every { tupleQuery.fetch() } returns listOf(tuple2)
 
             val result = repository.findUnembedded(pageSize = 10, afterStarCount = 2000L, afterId = 1L)
@@ -430,10 +516,12 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
         test("결과가 없으면 빈 리스트를 반환한다") {
             val tupleQuery = mockk<JPAQuery<Tuple>>()
+            val repo = QGithubRepository.githubRepository
+            val readme = QGithubRepositoryReadme.githubRepositoryReadme
 
-            every { queryFactory.select(any(), any()) } returns tupleQuery
-            every { tupleQuery.from(QGithubRepository.githubRepository) } returns tupleQuery
-            every { tupleQuery.join(QGithubRepositoryReadme.githubRepositoryReadme) } returns tupleQuery
+            every { queryFactory.select(repo, readme) } returns tupleQuery
+            every { tupleQuery.from(repo) } returns tupleQuery
+            every { tupleQuery.join(readme) } returns tupleQuery
             every { tupleQuery.on(any<BooleanExpression>()) } returns tupleQuery
             every { tupleQuery.where(any(), any(), any(), isNull()) } returns tupleQuery
             every { tupleQuery.orderBy(any(), any()) } returns tupleQuery
@@ -447,10 +535,12 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
 
         test("pageSize가 limit()에 정확히 전달된다") {
             val tupleQuery = mockk<JPAQuery<Tuple>>()
+            val repo = QGithubRepository.githubRepository
+            val readme = QGithubRepositoryReadme.githubRepositoryReadme
 
-            every { queryFactory.select(any(), any()) } returns tupleQuery
-            every { tupleQuery.from(QGithubRepository.githubRepository) } returns tupleQuery
-            every { tupleQuery.join(QGithubRepositoryReadme.githubRepositoryReadme) } returns tupleQuery
+            every { queryFactory.select(repo, readme) } returns tupleQuery
+            every { tupleQuery.from(repo) } returns tupleQuery
+            every { tupleQuery.join(readme) } returns tupleQuery
             every { tupleQuery.on(any<BooleanExpression>()) } returns tupleQuery
             every { tupleQuery.where(any(), any(), any(), isNull()) } returns tupleQuery
             every { tupleQuery.orderBy(any(), any()) } returns tupleQuery
@@ -460,6 +550,82 @@ class GithubRepositoryRepositoryImplTest : FunSpec({
             repository.findUnembedded(pageSize = 7, afterStarCount = null, afterId = null)
 
             verify { tupleQuery.limit(7L) }
+        }
+    }
+
+    context("findRepositoriesByCursor") {
+        test("cursor를 사용하여 레포지토리를 조회한다") {
+            val repo = QGithubRepository.githubRepository
+            val readme = QGithubRepositoryReadme.githubRepositoryReadme
+            val query = mockk<JPAQuery<Tuple>>()
+            val tuple1 = mockk<Tuple>()
+
+            every { queryFactory.select(repo, readme) } returns query
+            every { query.from(repo) } returns query
+            every { query.leftJoin(readme) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
+            every { query.where(isNull<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
+            every { query.orderBy(any(), any()) } returns query
+            every { query.limit(10L) } returns query
+            every { query.fetch() } returns listOf(tuple1)
+            every { tuple1.get(repo) } returns entity1
+            every { tuple1.get(readme) } returns null
+
+            val result = repository.findRepositoriesByCursor(10, GithubSortType.STARS, null, null)
+
+            result shouldHaveSize 1
+            result[0].id shouldBe 1L
+        }
+    }
+
+    context("findForCommunityCollect") {
+        test("커뮤니티 수집 대상 레포지토리를 조회한다") {
+            val repo = QGithubRepository.githubRepository
+            val community = QGithubRepositoryCommunity.githubRepositoryCommunity
+            val query = mockk<JPAQuery<Tuple>>()
+            val tuple1 = mockk<Tuple>()
+
+            every { queryFactory.select(repo, community) } returns query
+            every { query.from(repo) } returns query
+            every { query.leftJoin(community) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
+            every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
+            every { query.orderBy(any(), any()) } returns query
+            every { query.limit(10L) } returns query
+            every { query.fetch() } returns listOf(tuple1)
+            every { tuple1.get(repo) } returns entity1
+            every { tuple1.get(community) } returns null
+
+            val result = repository.findForCommunityCollect(
+                10, null, null,
+                LocalDateTime.now(), LocalDateTime.now()
+            )
+
+            result shouldHaveSize 1
+        }
+    }
+
+    context("findForCommunityAnalyze") {
+        test("커뮤니티 분석 대상 레포지토리를 조회한다") {
+            val repo = QGithubRepository.githubRepository
+            val community = QGithubRepositoryCommunity.githubRepositoryCommunity
+            val query = mockk<JPAQuery<Tuple>>()
+            val tuple1 = mockk<Tuple>()
+
+            every { queryFactory.select(repo, community) } returns query
+            every { query.from(repo) } returns query
+            every { query.join(community) } returns query
+            every { query.on(any<BooleanExpression>()) } returns query
+            every { query.where(any<BooleanExpression>(), isNull<BooleanExpression>()) } returns query
+            every { query.orderBy(any()) } returns query
+            every { query.limit(10L) } returns query
+            every { query.fetch() } returns listOf(tuple1)
+            every { tuple1.get(repo) } returns entity1
+            every { tuple1.get(community) } returns null
+
+            val result = repository.findForCommunityAnalyze(10, null)
+
+            result shouldHaveSize 1
         }
     }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * GitHub 저장소 응답에 README 요약이 포함되어 저장소 조회 시 더 풍부한 정보 제공.

* **Chores**
  * 로컬 개발 환경의 로깅 구성을 간소화하여 콘솔 출력 중심으로 조정.

* **Tests**
  * README 요약 매핑과 관련된 테스트를 추가·보완하여 응답 일관성 및 회귀 방지 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->